### PR TITLE
Allow installation of SimplePie 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "email": "support@anomaly.is"
     },
     "require": {
-        "simplepie/simplepie": "~1.5.0"
+        "simplepie/simplepie": "^1.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
SimplePie 1.6.0 was released yesterday. Because SimplePie follows SemVer it is save to use the "semver caret".

This will also fix #7.